### PR TITLE
Enhance Audio Encoding using clock rate and rtp clock rate of the Codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Several projects permits to understand how the library can be used:
     - Play Video file (Display it in ASCII in a Console/Terminal Window)
     
 - [CheckCodec](./test/CheckCodec) - **Multiplatform application**:
-    - Let user select an Audio Playback device and an Audio Recording device
-    - Let user select one of Audio Codec supported  
-    - Play back the sound from selected Audio Recording device after Encoding then Decoding the sample 
+    - Let user select an Audio Playback device
+    - Let user select an Audio Recording device OR a Video File
+    - Let user select one of the Audio Codecs supported  
+    - Play back the sound after Encoding then Decoding the sample using the specified codec 

--- a/src/SDL2AudioSource.cs
+++ b/src/SDL2AudioSource.cs
@@ -86,7 +86,7 @@ namespace SIPSorceryMedia.SDL2
                             {
                                 var encodedSample = _audioEncoder.EncodeAudio(pcm, _audioFormatManager.SelectedFormat);
                                 if (encodedSample.Length > 0)
-                                    OnAudioSourceEncodedSample?.Invoke((uint)pcm.Length, encodedSample);
+                                    OnAudioSourceEncodedSample?.Invoke((uint)( pcm.Length * _audioFormatManager.SelectedFormat.RtpClockRate / _audioFormatManager.SelectedFormat.ClockRate), encodedSample);
                             }
                         }
 

--- a/src/SIPSorceryMedia.SDL2.csproj
+++ b/src/SIPSorceryMedia.SDL2.csproj
@@ -5,10 +5,18 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<Version>1.0.0</Version>
+	<Version>1.1.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
+    <Authors>Christophe Irles</Authors>
+    <Description>
+		This project is an example of developing a C# library that can use features from [SDL2](https://www.libsdl.org/index.php) native libraries and that integrates with the [SIPSorcery](https://github.com/sipsorcery-org/sipsorcery) real-time communications library.
+
+		The classes in this project provide Audio End Point and Audio Source features.
+
+		Audio Codecs supported by this library: PCMU (G711), PCMA (G711), G722, G729 and Opus
+	</Description>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/SIPSorceryMedia.SDL2.nuspec
+++ b/src/SIPSorceryMedia.SDL2.nuspec
@@ -18,6 +18,7 @@
       <dependency id="SIPSorceryMedia.Abstractions" Version="1.2.0" />
     </dependencies>
 	<releaseNotes>
+-v1.1.0: Enhance Audio Source encoding. Audio Codecs tested: PCMU (G711), PCMA (G711), G722, G729 and Opus
 -v1.0.0: Audio Source and Audio End Point       
 	</releaseNotes>
 	<version>1.0.0</version>

--- a/test/CheckCodec/CheckCodec.csproj
+++ b/test/CheckCodec/CheckCodec.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
     <PackageReference Include="SIPSorcery" Version="6.0.7" />
+    <PackageReference Include="SIPSorceryMedia.FFmpeg" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PlayVideoFile/ProgramPlayVideoFile.cs
+++ b/test/PlayVideoFile/ProgramPlayVideoFile.cs
@@ -52,7 +52,7 @@ namespace PlayVideoFile
             // Quit since no Audio playback found
             if ((sdlDevices == null) || (sdlDevices.Count == 0))
             {
-                Console.WriteLine("No Audio playbqck devices found ...");
+                Console.WriteLine("No Audio playback devices found ...");
                 SDL2Helper.QuitSDL();
                 return;
             }


### PR DESCRIPTION
Take into account clock rate and rtp clock rate when using OnAudioSourceEncodedSample
Enhance CheckCodec example: it's now possible to choose Audio Recording Device or a Video File
Update README
Increase release to v1.1.0