### PR TITLE
Small improvement and remove compilation warnings

### DIFF
--- a/src/SIPSorceryMedia.SDL2.csproj
+++ b/src/SIPSorceryMedia.SDL2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<Version>1.1.0</Version>
+	<Version>1.1.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -22,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### PR Content:

- Call StartAudio when SetAudioSourceFormat is used. 

- Call StartAudioSink when SetAudioSinkFormat is used.

- Remove unnecessary reference to package Microsoft.Extensions.Logging.Abstractions. 

- Update code to remove compilation warnings

- Increase release to 1.1.1